### PR TITLE
add notice about the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 Test between Wazo and Matrix using Mautrix.
 
+**Notice**: This plugin require modification to wazo-chatd event system. This is not intended to be
+functional, but more a discovery on the subject
+
 ```bash
 python -m venv env
 . ./env/bin/activate


### PR DESCRIPTION
Can you transfer the owner to the wazo-platform?
If so, also rename with `hackathon` prefix (ex: `hackathon-2022-mautrix-wazo`)